### PR TITLE
Modernize swift log interface

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "f4240bf022a69815241a883c03645444b58ac553",
-          "version": "1.1.0"
+          "revision": "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
+          "version": "1.6.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
             targets: ["LoggingFormatAndPipe"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.3.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
             targets: ["LoggingFormatAndPipe"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
     ],
     targets: [
         .target(

--- a/Sources/LoggingFormatAndPipe/BasicFormatter.swift
+++ b/Sources/LoggingFormatAndPipe/BasicFormatter.swift
@@ -49,11 +49,12 @@ public struct BasicFormatter: Formatter {
     public func processLog(level: Logger.Level,
                            message: Logger.Message,
                            prettyMetadata: String?,
+                           source: String,
                            file: String, function: String, line: UInt) -> String {
         let now = Date()
 
         return self.format.map({ (component) -> String in
-            return self.processComponent(component, now: now, level: level, message: message, prettyMetadata: prettyMetadata, file: file, function: function, line: line)
+            return self.processComponent(component, now: now, level: level, message: message, prettyMetadata: prettyMetadata, source: source, file: file, function: function, line: line)
         }).filter({ (string) -> Bool in
             return string.count > 0
         }).joined(separator: self.separator ?? "")

--- a/Sources/LoggingFormatAndPipe/BasicFormatter.swift
+++ b/Sources/LoggingFormatAndPipe/BasicFormatter.swift
@@ -40,6 +40,7 @@ public struct BasicFormatter: Formatter {
     /// Our main log formatting method
     /// - Parameters:
     ///   - level: log level
+    ///   - label: logger label
     ///   - message: actual message
     ///   - prettyMetadata: optional metadata that has already been "prettified"
     ///   - file: log's originating file
@@ -47,6 +48,7 @@ public struct BasicFormatter: Formatter {
     ///   - line: log's originating line
     /// - Returns: Result of formatting the log
     public func processLog(level: Logger.Level,
+                           label: String,
                            message: Logger.Message,
                            prettyMetadata: String?,
                            source: String,
@@ -54,7 +56,7 @@ public struct BasicFormatter: Formatter {
         let now = Date()
 
         return self.format.map({ (component) -> String in
-            return self.processComponent(component, now: now, level: level, message: message, prettyMetadata: prettyMetadata, source: source, file: file, function: function, line: line)
+            return self.processComponent(component, now: now, level: level, label: label, message: message, prettyMetadata: prettyMetadata, source: source, file: file, function: function, line: line)
         }).filter({ (string) -> Bool in
             return string.count > 0
         }).joined(separator: self.separator ?? "")

--- a/Sources/LoggingFormatAndPipe/Formatter.swift
+++ b/Sources/LoggingFormatAndPipe/Formatter.swift
@@ -20,6 +20,8 @@ public enum LogComponent {
     case message
     /// Log metadata
     case metadata
+    /// Log source
+    case source
     /// The log's originating file
     case file
     /// The log's originating function
@@ -39,6 +41,7 @@ public enum LogComponent {
             .level,
             .message,
             .metadata,
+            .source,
             .file,
             .function,
             .line
@@ -62,6 +65,7 @@ public protocol Formatter {
     func processLog(level: Logger.Level,
                     message: Logger.Message,
                     prettyMetadata: String?,
+                    source: String,
                     file: String, function: String, line: UInt) -> String
 
 }
@@ -80,6 +84,7 @@ extension Formatter {
     public func processComponent(_ component: LogComponent, now: Date, level: Logger.Level,
                                   message: Logger.Message,
                                   prettyMetadata: String?,
+                                  source: String,
                                   file: String, function: String, line: UInt) -> String {
         switch component {
         case .timestamp:
@@ -90,6 +95,8 @@ extension Formatter {
             return "\(message)"
         case .metadata:
             return "\(prettyMetadata.map { "\($0)" } ?? "")"
+        case .source:
+            return "\(source)"
         case .file:
             return "\(file)"
         case .function:
@@ -100,7 +107,7 @@ extension Formatter {
             return string
         case .group(let logComponents):
             return logComponents.map({ (component) -> String in
-                self.processComponent(component, now: now, level: level, message: message, prettyMetadata: prettyMetadata, file: file, function: function, line: line)
+                self.processComponent(component, now: now, level: level, message: message, prettyMetadata: prettyMetadata, source: source, file: file, function: function, line: line)
             }).joined()
         }
     }

--- a/Sources/LoggingFormatAndPipe/Formatter.swift
+++ b/Sources/LoggingFormatAndPipe/Formatter.swift
@@ -14,6 +14,8 @@ public enum LogComponent {
     /// Specifying your timestamp format can be done by providing a DateFormatter through `Formatter.timestampFormatter`
     case timestamp
 
+    /// Logger label
+    case label
     /// Log level
     case level
     /// The actual message
@@ -39,6 +41,7 @@ public enum LogComponent {
         return [
             .timestamp,
             .level,
+            .label,
             .message,
             .metadata,
             .source,
@@ -56,6 +59,7 @@ public protocol Formatter {
 
     /// Formatter's chance to format the log
     /// - Parameter level: log level
+    /// - Parameter label: logger label
     /// - Parameter message: actual message
     /// - Parameter prettyMetadata: optional metadata that has already been "prettified"
     /// - Parameter file: log's originating file
@@ -63,6 +67,7 @@ public protocol Formatter {
     /// - Parameter line: log's originating line
     /// - Returns: Result of formatting the log
     func processLog(level: Logger.Level,
+                    label: String,
                     message: Logger.Message,
                     prettyMetadata: String?,
                     source: String,
@@ -82,6 +87,7 @@ extension Formatter {
     /// - Parameter line: log's originating line
     /// - Returns: Result of formatting the component
     public func processComponent(_ component: LogComponent, now: Date, level: Logger.Level,
+                                  label: String,
                                   message: Logger.Message,
                                   prettyMetadata: String?,
                                   source: String,
@@ -89,6 +95,8 @@ extension Formatter {
         switch component {
         case .timestamp:
             return self.timestampFormatter.string(from: now)
+        case .label:
+            return "\(label)"
         case .level:
             return "\(level)"
         case .message:
@@ -107,7 +115,7 @@ extension Formatter {
             return string
         case .group(let logComponents):
             return logComponents.map({ (component) -> String in
-                self.processComponent(component, now: now, level: level, message: message, prettyMetadata: prettyMetadata, source: source, file: file, function: function, line: line)
+                self.processComponent(component, now: now, level: level, label: label, message: message, prettyMetadata: prettyMetadata, source: source, file: file, function: function, line: line)
             }).joined()
         }
     }

--- a/Sources/LoggingFormatAndPipe/Handler.swift
+++ b/Sources/LoggingFormatAndPipe/Handler.swift
@@ -31,12 +31,17 @@ public struct Handler: LogHandler {
     public func log(level: Logger.Level,
                     message: Logger.Message,
                     metadata: Logger.Metadata?,
+                    source: String,
                     file: String, function: String, line: UInt) {
         let prettyMetadata = metadata?.isEmpty ?? true
             ? self.prettyMetadata
             : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
 
-        let formattedMessage = self.formatter.processLog(level: level, message: message, prettyMetadata: prettyMetadata, file: file, function: function, line: line)
+        let formattedMessage = self.formatter.processLog(level: level,
+                                                         message: message,
+                                                         prettyMetadata: prettyMetadata,
+                                                         source: source,
+                                                         file: file, function: function, line: line)
         self.pipe.handle(formattedMessage)
     }
 

--- a/Sources/LoggingFormatAndPipe/Handler.swift
+++ b/Sources/LoggingFormatAndPipe/Handler.swift
@@ -13,10 +13,14 @@ public struct Handler: LogHandler {
     /// - parameters:
     ///   - formatter: Formatter to format with
     ///   - pipe: PIpe to pipe to
-    public init(formatter: Formatter, pipe: Pipe) {
+    public init(label: String, formatter: Formatter, pipe: Pipe) {
+        self.label = label
         self.formatter = formatter
         self.pipe = pipe
     }
+
+    /// Label of the logger
+    public let label: String
 
     /// Formatter we're formatting with
     public let formatter: Formatter
@@ -38,6 +42,7 @@ public struct Handler: LogHandler {
             : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
 
         let formattedMessage = self.formatter.processLog(level: level,
+                                                         label: self.label,
                                                          message: message,
                                                          prettyMetadata: prettyMetadata,
                                                          source: source,

--- a/Tests/LoggingFormatAndPipeTests/FormatterTests.swift
+++ b/Tests/LoggingFormatAndPipeTests/FormatterTests.swift
@@ -13,8 +13,9 @@ final class FormatterTests: XCTestCase {
     func testFormatter(_ formatter: LoggingFormatAndPipe.Formatter) {
         let pipe = HistoryPipe()
 
-        let logger = Logger(label: "test\(type(of: formatter))") { _ in
+        let logger = Logger(label: "test\(type(of: formatter))") { label in
             return LoggingFormatAndPipe.Handler(
+                label: label,
                 formatter: formatter,
                 pipe: pipe
             )

--- a/Tests/LoggingFormatAndPipeTests/HandlerTests.swift
+++ b/Tests/LoggingFormatAndPipeTests/HandlerTests.swift
@@ -12,8 +12,9 @@ import LoggingFormatAndPipe
 final class HandlerTests: XCTestCase {
     func testPiping() {
         let pipe = HistoryPipe()
-        let logger = Logger(label: "testPiping") { _ in
+        let logger = Logger(label: "testPiping") { label in
             return LoggingFormatAndPipe.Handler(
+                label: label,
                 formatter: BasicFormatter(),
                 pipe: pipe
             )

--- a/Tests/LoggingFormatAndPipeTests/LoggerTextOutputStreamPipeTests.swift
+++ b/Tests/LoggingFormatAndPipeTests/LoggerTextOutputStreamPipeTests.swift
@@ -11,8 +11,9 @@ import LoggingFormatAndPipe
 
 final class LoggerTextOutputStreamPipeTests: XCTestCase {
     func testStdout() {
-        let logger = Logger(label: "testStdout") { _ in
+        let logger = Logger(label: "testStdout") { label in
             return LoggingFormatAndPipe.Handler(
+            label: label,
             formatter: BasicFormatter(),
             pipe: LoggerTextOutputStreamPipe.standardOutput
             )
@@ -26,8 +27,9 @@ final class LoggerTextOutputStreamPipeTests: XCTestCase {
     }
 
     func testStderr() {
-        let logger = Logger(label: "testStderr") { _ in
+        let logger = Logger(label: "testStderr") { label in
             return LoggingFormatAndPipe.Handler(
+                label: label,
                 formatter: BasicFormatter(),
                 pipe: LoggerTextOutputStreamPipe.standardError
             )


### PR DESCRIPTION
Add support for:

1. `source` property of a log message
2. `label` property of a logger